### PR TITLE
Error class inheriting from Exception line 161

### DIFF
--- a/spec/unit/rack/params_spec.rb
+++ b/spec/unit/rack/params_spec.rb
@@ -158,7 +158,7 @@ Berry\r
     end
 
     it 'does not swallow exceptions from the app' do
-      app_exception = Class.new(Exception)
+      app_exception = Class.new(RuntimeError)
       expect(@app).to receive(:call).and_raise(app_exception)
       expect { @params.call(@env) }.to raise_error(app_exception)
     end


### PR DESCRIPTION

Error classes must inherit from RuntimeError instead.

Example - The bad way:

class C < Exception; end
C = Class.new(Exception)

Example - The good way:

class C < RuntimeError; end
C = Class.new(RuntimeError)

### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL:

### ⚙️ Description *

_Describe your fix clearly and concisely - imagine you are describing it to a non-technical friend._

### 💻 Technical Description *

_Describe in-depth, the technical implementation of the proposed security fix. Imagine you are describing it to a NASA engineer._

### 🐛 Proof of Concept (PoC) *

_Provide the vulnerability exploit to show the security issue you're fixing._

### 🔥 Proof of Fix (PoF) *

_Replay the vulnerability exploit to show the successful fix and mitigation of the vulnerability._

### 👍 User Acceptance Testing (UAT)

_Run a unit test or a legitimate use case to prove that your fix does not introduce breaking changes._
